### PR TITLE
fix: update to eliminate the need to pass account & region in script

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -3,6 +3,7 @@
 This example deploys AWS rolesanywhere for a pattern of using it DoD cac authentication.
 
 Once this terraform is deployed, you can configure an aws profile to use rolesanywhere by doing the following:
+
 ```bash
 # download aws signing helper and put in path somewhere, see docs here:
 # https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html
@@ -19,7 +20,7 @@ pkcs11-tool --list-objects --type cert | grep -B 1 -A 3 "Certificate for PIV Aut
 pkcs11-tool --read-object --type cert --id $ID_FROM_PIV_CERT_OUTPUT | openssl x509 -inform DER  -text -noout -issuer | grep 'Issuer:'
 
 # fetch creds using rolesanywhere and your smartcard
-./aws_signing_helper credential-process --cert-selector 'Key=x509Serial,Value=$PIV_CERT_SERIAL' --trust-anchor-arn $ARN_OF_MATCHING_PIV_CERT_ISSUER_CA --profile-arn $ARN_OF_RA_PROFILE --role-arn $ARN_OF_ROLE_TO_ASSUME --aws-account-number $AWS_ACCOUNT_NUMBER --aws-default-region $AWS_DEFAULT_REGION
+./aws_signing_helper credential-process --cert-selector 'Key=x509Serial,Value=$PIV_CERT_SERIAL' --trust-anchor-arn $ARN_OF_MATCHING_PIV_CERT_ISSUER_CA --profile-arn $ARN_OF_RA_PROFILE --role-arn $ARN_OF_ROLE_TO_ASSUME
 
 ```
 
@@ -31,7 +32,7 @@ You can hardcode everything in here:
 ```ini
 [profile ra-cac]
 region=us-gov-west-1
-credential_process=credential-process --cert-selector 'Key=x509Serial,Value=$PIV_CERT_SERIAL' --trust-anchor-arn $ARN_OF_MATCHING_PIV_CERT_ISSUER_CA --profile-arn $ARN_OF_RA_PROFILE --role-arn $ARN_OF_ROLE_TO_ASSUME --aws-account-number $AWS_ACCOUNT_NUMBER --aws-default-region $AWS_DEFAULT_REGION
+credential_process=credential-process --cert-selector 'Key=x509Serial,Value=$PIV_CERT_SERIAL' --trust-anchor-arn $ARN_OF_MATCHING_PIV_CERT_ISSUER_CA --profile-arn $ARN_OF_RA_PROFILE --role-arn $ARN_OF_ROLE_TO_ASSUME
 ```
 
 Then set profile via `export AWS_PROFILE=ra-cac` or `--profile ra-cac` on aws cli commands
@@ -45,9 +46,7 @@ These creds will expire after 1 hour.
 source ./aws_login_rolesanywhere.sh \
   --trust-anchor-arn "$ARN_OF_MATCHING_PIV_CERT_ISSUER_CA" \
   --profile-arn "$ARN_OF_RA_PROFILE" \
-  --role-arn "$ARN_OF_ROLE_TO_ASSUME" \
-  --aws-account-number $AWS_ACCOUNT_NUMBER \
-  --aws-default-region $AWS_DEFAULT_REGION
+  --role-arn "$ARN_OF_ROLE_TO_ASSUME"
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/aws_login_rolesanywhere.sh
+++ b/examples/complete/aws_login_rolesanywhere.sh
@@ -6,9 +6,8 @@
 
 # see https://github.com/aws/rolesanywhere-credential-helper?tab=readme-ov-file#credential-process for more info
 
-#unset AWS_PROFILE AWS_SESSION_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID AWS_DEFAULT_REGION AWS_ACCOUNT_NUMBER AWS_USERNAME AWS_IAM_ROLE
 # Only clear the env that is being reset below
-unset AWS_SESSION_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID AWS_DEFAULT_REGION AWS_ACCOUNT_NUMBER 
+unset AWS_SESSION_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID AWS_DEFAULT_REGION AWS_ACCOUNT_NUMBER
 
 echo -e "Starting script with $# arguments: $@\n"
 

--- a/examples/complete/aws_login_rolesanywhere.sh
+++ b/examples/complete/aws_login_rolesanywhere.sh
@@ -6,7 +6,9 @@
 
 # see https://github.com/aws/rolesanywhere-credential-helper?tab=readme-ov-file#credential-process for more info
 
-unset AWS_PROFILE AWS_SESSION_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID AWS_DEFAULT_REGION AWS_ACCOUNT_NUMBER AWS_USERNAME AWS_IAM_ROLE
+#unset AWS_PROFILE AWS_SESSION_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID AWS_DEFAULT_REGION AWS_ACCOUNT_NUMBER AWS_USERNAME AWS_IAM_ROLE
+# Only clear the env that is being reset below
+unset AWS_SESSION_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID AWS_DEFAULT_REGION AWS_ACCOUNT_NUMBER 
 
 echo -e "Starting script with $# arguments: $@\n"
 
@@ -74,28 +76,6 @@ while (("$#")); do
       exit 1
     fi
     ;;
-    # aws account number
-  --aws-account-number)
-    if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-    AWS_ACCOUNT_NUMBER=$2
-    shift 2
-    else
-      echo "Error: Argument for $1 is missing" >&2
-      help
-      exit 1
-    fi
-    ;;
-    # aws default region
-  --aws-default-region)
-    if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-    AWS_DEFAULT_REGION=$2
-    shift 2
-    else
-      echo "Error: Argument for $1 is missing" >&2
-      help
-      exit 1
-    fi
-    ;;
   # help message
   -h | --help)
     help
@@ -115,10 +95,12 @@ while (("$#")); do
   esac
 done
 
+AWS_ACCOUNT_NUMBER=$(echo "${PROFILE_ARN}" | awk -F':' '{print $5}')
+AWS_DEFAULT_REGION=$(echo "${PROFILE_ARN}" | awk -F':' '{print $4}')
 
 # get user's piv cert information
 PIV_CERT_INFO=$(pkcs11-tool --list-objects --type cert | grep -B 1 -A 3 "Certificate for PIV Authentication")
-PIV_CERT_SERIAL=${PIV_CERT_SERIAL:-$(echo "$PIV_CERT_INFO" | grep "serial:" | awk '{print $2}')}
+PIV_CERT_SERIAL=$(echo "${PIV_CERT_INFO}" | awk '/serial:/ {print $2}')
 
 cred=$(aws_signing_helper \
   credential-process \


### PR DESCRIPTION
The account and region is found the TA and profile arn's, I thought they could just be extracted from and exported as before. Also, some of the env vars are being unset for not reset, is that on purpose to eliminate extra env vars?